### PR TITLE
view: Add @thumbs-contrast option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ NOTE: for changes to take effect, you'll need to source again your `.tmux.conf` 
 * [@thumbs-hint-bg-color](#thumbs-hint-bg-color)
 * [@thumbs-hint-fg-color](#thumbs-hint-fg-color)
 * [@thumbs-select-fg-color](#thumbs-select-fg-color)
+* [@thumbs-contrast](#thumbs-contrast)
 
 ### @thumbs-key
 
@@ -232,6 +233,18 @@ For example:
 
 ```
 set -g @thumbs-select-fg-color red
+```
+
+### @thumbs-contrast
+
+`default: 0`
+
+Displays hint character in square brackets for extra visibility.
+
+For example:
+
+```
+set -g @thumbs-contrast 1
 ```
 
 #### Colors

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,12 @@ fn app_args<'a>() -> clap::ArgMatches<'a> {
         .takes_value(true)
         .multiple(true),
     )
+    .arg(
+      Arg::with_name("contrast")
+        .help("Put square brackets around hint for visibility")
+        .long("contrast")
+        .short("c"),
+    )
     .get_matches();
 }
 
@@ -114,6 +120,7 @@ fn main() {
   let position = args.value_of("position").unwrap();
   let reverse = args.is_present("reverse");
   let unique = args.is_present("unique");
+  let contrast = args.is_present("contrast");
   let regexp = if let Some(items) = args.values_of("regexp") {
     items.collect::<Vec<_>>()
   } else {
@@ -146,6 +153,7 @@ fn main() {
       &mut state,
       reverse,
       unique,
+      contrast,
       position,
       select_foreground_color,
       foreground_color,

--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -42,6 +42,7 @@ PARAMS[8]=$(option select-fg-color)
 PARAMS[9]=$(option command)
 PARAMS[10]=$(option upcase-command)
 PARAMS[11]=$(multi regexp)
+PARAMS[12]=$(boolean contrast)
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TARGET_RELEASE="/target/release/"


### PR DESCRIPTION
Add an option to enable a "full" hint where the hint letter is surrounded by square brackets (for example `[a]` rather than `a`). This is the equivalent to the following `tmux-fingers` configuration option [1] and is useful to make the hint more visible:

```
set -g @fingers-compact-hints 0
```

[1] - https://github.com/Morantron/tmux-fingers#fingers-compact-hints

Signed-off-by: James O. D. Hunt <jamesodhunt@gmail.com>