### PR TITLE
Fixes passing options with spaces in the value

### DIFF
--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -2,53 +2,55 @@
 
 source ~/.bash_profile
 
-function boolean {
+PARAMS=()
+
+function add-boolean-param {
   VALUE=$(tmux show -vg @thumbs-$1 2> /dev/null)
 
   if [[ "${VALUE}" == "1" ]]; then
-    echo "--$1"
+    PARAMS+=("--$1")
   fi
 }
 
-function option {
+function add-option-param {
   VALUE=$(tmux show -vg @thumbs-$1 2> /dev/null)
 
   if [[ ${VALUE} ]]; then
-    echo "--$1 ${VALUE}"
+    PARAMS+=("--$1=${VALUE}")
   fi
 }
 
-function multi {
-  VALUES=""
-
+function add-multi-param {
   while read -r ITEM_KEY; do
     VALUE=$(tmux show -vg $ITEM_KEY 2> /dev/null)
-    VALUES="${VALUES} --$1 ${VALUE}"
+    PARAMS+=("--$1=${VALUE}")
   done < <(tmux show -g 2> /dev/null | grep thumbs-$1- | cut -d' ' -f1)
-
-  echo ${VALUES}
 }
 
-PARAMS=()
-PARAMS[0]=$(boolean reverse)
-PARAMS[1]=$(boolean unique)
-PARAMS[2]=$(option alphabet)
-PARAMS[3]=$(option position)
-PARAMS[4]=$(option fg-color)
-PARAMS[5]=$(option bg-color)
-PARAMS[6]=$(option hint-bg-color)
-PARAMS[7]=$(option hint-fg-color)
-PARAMS[8]=$(option select-fg-color)
-PARAMS[9]=$(option command)
-PARAMS[10]=$(option upcase-command)
-PARAMS[11]=$(multi regexp)
-PARAMS[12]=$(boolean contrast)
+add-boolean-param "reverse"
+add-boolean-param "unique"
+add-option-param  "alphabet"
+add-option-param  "position"
+add-option-param  "fg-color"
+add-option-param  "bg-color"
+add-option-param  "hint-bg-color"
+add-option-param  "hint-fg-color"
+add-option-param  "select-fg-color"
+add-option-param  "command"
+add-option-param  "upcase-command"
+add-multi-param   "regexp"
+add-boolean-param "contrast"
+
+# Remove empty arguments from PARAMS.
+# Otherwise, they would choke up tmux-thumbs when passed to it.
+for i in "${!PARAMS[@]}"; do
+  [ -n "${PARAMS[$i]}" ] || unset "PARAMS[$i]"
+done
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TARGET_RELEASE="/target/release/"
 CURRENT_PANE_ID=$(tmux list-panes -F "#{pane_id}:#{?pane_active,active,nope}" | grep active | cut -d: -f1)
-COMMAND="tmux-thumbs ${PARAMS[*]} --tmux-pane ${CURRENT_PANE_ID}"
-NEW_ID=$(tmux new-window -P -d -n "[thumbs]" ${CURRENT_DIR}${TARGET_RELEASE}${COMMAND})
+NEW_ID=$(tmux new-window -P -d -n "[thumbs]" ${CURRENT_DIR}${TARGET_RELEASE}tmux-thumbs "${PARAMS[@]}" "--tmux-pane=${CURRENT_PANE_ID}")
 NEW_PANE_ID=$(tmux list-panes -a | grep ${NEW_ID} | grep --color=never -o '%[0-9]\+')
 
 tmux swap-pane -d -s ${CURRENT_PANE_ID} -t ${NEW_PANE_ID}


### PR DESCRIPTION
Previously, when setting the `--command` option to `tmux set-buffer {}`, it
will be interpreted by the `tmux-thumbs` binary as 4 separate args:
`--command`, `'tmux`, `set-buffer`, and `{}'`. This commit fixes it such that
the option will be correctly interpreted as a single arg.