### PR TITLE
swapper: Make quotes optional in key-value regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ This is the known list of versions of `tmux` compatible with `tmux-thumbs`:
 
 | Version | Compatible |
 |:-------:|:----------:|
-|   3.0a  |      ❓    |
+|   3.0a  |     ✅     |
 |   2.9a  |     ✅     |
 |   2.8   |      ❓    |
 |   2.7   |      ❓    |

--- a/src/swapper.rs
+++ b/src/swapper.rs
@@ -127,7 +127,7 @@ impl<'a> Swapper<'a> {
     let options = self.executor.execute(params);
     let lines: Vec<&str> = options.split('\n').collect();
 
-    let pattern = Regex::new(r#"@thumbs-([\w\-0-9]+) "(.*)""#).unwrap();
+    let pattern = Regex::new(r#"@thumbs-([\w\-0-9]+) "?(\w+)"?"#).unwrap();
 
     let args = lines
       .iter()


### PR DESCRIPTION
The regular expression describing the tmux user options expects to find
quotes around the value. However, in at least tmux 3.0a the
`show-options -g` command doesn't display quotes around the values,
which means the regex fails.

For example, the current regex will fail to find these user options:

	$ tmux -V
	tmux 3.0a

	$ tmux show -g | grep -E "@thumbs"
	@thumbs-bg-color default
	@thumbs-fg-color green
	@thumbs-hint-bg-color default
	@thumbs-hint-fg-color blue
	@thumbs-select-bg-color default
	@thumbs-select-fg-color green

Make the quotes optional so that these options are picked up.

Fixes #33