### PR TITLE
let user specify a prefix-less @thumbs-key binding

### DIFF
--- a/tmux-thumbs.tmux
+++ b/tmux-thumbs.tmux
@@ -6,7 +6,7 @@ DEFAULT_THUMBS_KEY="space"
 THUMBS_KEY=$(tmux show-option -gqv @thumbs-key)
 THUMBS_KEY=${THUMBS_KEY:-$DEFAULT_THUMBS_KEY}
 
-tmux bind-key "$THUMBS_KEY" run-shell -b "${CURRENT_DIR}/tmux-thumbs.sh"
+tmux bind-key $THUMBS_KEY run-shell -b "${CURRENT_DIR}/tmux-thumbs.sh"
 
 BINARY="${CURRENT_DIR}/target/release/thumbs"
 


### PR DESCRIPTION
This change allows me to bind a prefix-less shortcut for @thumbs-key.
For example, I bind a prefix-less Alt+Shift+U instead of Prefix + Space:

    set -g @thumbs-key '-n M-U'