### PR TITLE
remove line brackets from contrast

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -89,9 +89,7 @@ impl<'a> View<'a> {
       let clean = line.trim_end_matches(|c: char| c.is_whitespace());
 
       if !clean.is_empty() {
-        let text = line.to_string();
-
-        print!("{goto}{text}", goto = cursor::Goto(1, index as u16 + 1), text = &text);
+        print!("{goto}{text}", goto = cursor::Goto(1, index as u16 + 1), text = line);
       }
     }
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -89,7 +89,7 @@ impl<'a> View<'a> {
       let clean = line.trim_end_matches(|c: char| c.is_whitespace());
 
       if !clean.is_empty() {
-        let text = self.make_hint_text(line);
+        let text = line.to_string();
 
         print!("{goto}{text}", goto = cursor::Goto(1, index as u16 + 1), text = &text);
       }


### PR DESCRIPTION
to address #47 
hits get marked on line 117, not on 92, it should be safe to do `line.to_string()'