### PR TITLE
temporarily set visual-activity to off

### DIFF
--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -32,6 +32,10 @@ done
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-${CURRENT_DIR}/target/release/tmux-thumbs --dir "${CURRENT_DIR}" "${PARAMS[@]}"
+visual_activity=$(tmux show-options -g visual-activity | cut -f2 -d' ')
+
+tmux set-option -g visual-activity off
+  ${CURRENT_DIR}/target/release/tmux-thumbs --dir "${CURRENT_DIR}" "${PARAMS[@]}"
+tmux set-option -g visual-activity "${visual_activity}"
 
 true


### PR DESCRIPTION
tmux-thumbs is FASTER than tmux-fingers. If you have visual-activity
set to `on`, sometimes the process of marking the candidates gets
interrupted by tmux notifying that there's activity in window N.
In tmux fingers, the whole thing happens after the notification.

Setting the value to off and restoring it after thumbs run solves
it.


It's "racecondition-friendly" af, but can't think of a proper way to solve it properly, and by the nature of tmux, I don't think it's that much of a problem.

Tell me what you think 

PS: `remain-on-exit` option also gets in the way. I'm trying to figure out why tmux-fingers didn't, and maybe come with another option to shadow the values.
PS2: Oh, that -> https://github.com/Morantron/tmux-fingers/blob/master/scripts/fingers-mode.sh#L160 :).