### PR TITLE
Quoting fixes

### DIFF
--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -Eeu -o pipefail
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -5,24 +5,26 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PARAMS=()
 
 function add-boolean-param {
-  VALUE=$(tmux show -vg @thumbs-$1 2> /dev/null)
-
-  if [[ "${VALUE}" == "1" ]]; then
-    PARAMS+=("--$1")
+  local opt value
+  opt="${1}"
+  value="$(tmux show -vg "@thumbs-${opt}" 2> /dev/null)"
+  if [ "${value}" = 1 ]; then
+    PARAMS+=("--${opt}")
   fi
 }
 
 function add-option-param {
-  VALUE=$(tmux show -vg @thumbs-$1 2> /dev/null)
-
-  if [ -n "${VALUE}" ]; then
-    PARAMS+=("--$1=${VALUE}")
+  local opt value
+  opt="${1}"
+  value="$(tmux show -vg "@thumbs-${opt}" 2> /dev/null)"
+  if [ -n "${value}" ]; then
+    PARAMS+=("--${opt}=${value}")
   fi
 }
 
-add-option-param "command"
-add-option-param "upcase-command"
-add-boolean-param "osc52"
+add-option-param command
+add-option-param upcase-command
+add-boolean-param osc52
 
 # Remove empty arguments from PARAMS.
 # Otherwise, they would choke up tmux-thumbs when passed to it.
@@ -32,6 +34,6 @@ done
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-${CURRENT_DIR}/target/release/tmux-thumbs --dir "${CURRENT_DIR}" "${PARAMS[@]}"
+"${CURRENT_DIR}/target/release/tmux-thumbs" --dir "${CURRENT_DIR}" "${PARAMS[@]}"
 
 true

--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -15,7 +15,7 @@ function add-boolean-param {
 function add-option-param {
   VALUE=$(tmux show -vg @thumbs-$1 2> /dev/null)
 
-  if [[ ${VALUE} ]]; then
+  if [ -n "${VALUE}" ]; then
     PARAMS+=("--$1=${VALUE}")
   fi
 }

--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 PARAMS=()
 
 function add-boolean-param {

--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -4,11 +4,14 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 PARAMS=()
 
+function get-option() {
+  tmux show -vg "@thumbs-${1}" 2> /dev/null
+}
+
 function add-boolean-param {
-  local opt value
+  local opt
   opt="${1}"
-  value="$(tmux show -vg "@thumbs-${opt}" 2> /dev/null)"
-  if [ "${value}" = 1 ]; then
+  if [ "$(get-option "${opt}")" = 1 ]; then
     PARAMS+=("--${opt}")
   fi
 }
@@ -16,7 +19,7 @@ function add-boolean-param {
 function add-option-param {
   local opt value
   opt="${1}"
-  value="$(tmux show -vg "@thumbs-${opt}" 2> /dev/null)"
+  value="$(get-option "${opt}")"
   if [ -n "${value}" ]; then
     PARAMS+=("--${opt}=${value}")
   fi

--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-[ -f ~/.bash_profile ] && source ~/.bash_profile
-
 PARAMS=()
 
 function add-boolean-param {

--- a/tmux-thumbs.tmux
+++ b/tmux-thumbs.tmux
@@ -2,11 +2,12 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-DEFAULT_THUMBS_KEY="space"
-THUMBS_KEY=$(tmux show-option -gqv @thumbs-key)
+DEFAULT_THUMBS_KEY=space
+
+THUMBS_KEY="$(tmux show-option -gqv @thumbs-key)"
 THUMBS_KEY=${THUMBS_KEY:-$DEFAULT_THUMBS_KEY}
 
-tmux bind-key $THUMBS_KEY run-shell -b "${CURRENT_DIR}/tmux-thumbs.sh"
+tmux bind-key "${THUMBS_KEY}" run-shell -b "${CURRENT_DIR}/tmux-thumbs.sh"
 
 BINARY="${CURRENT_DIR}/target/release/thumbs"
 


### PR DESCRIPTION
Copying a token with a quote in it was failing silently, and I briefly looked into why.

There were a few quoting issues in the scripts (most of them harmless, but easily fixed up: and I might have tinkered with it more than I needed to! Sorry!).

Then looking into how commands were executed and that *had* to be fixed: it's currently super dangerous. This changes the command construction from splicing the literal copied text to splicing in a bash variable reference (better, but not great). Reproducing the comment here:

----

The command we run has two arguments:
 * The first arg is the (trimmed) text. This gets stored in a variable, in order to preserve quoting and special characters.

 * The second argument is the user's command, with the `'{}'` token replaced with an unquoted reference to the variable containing the text.

The reference is placed unquoted, unfortunately (i.e. `${THUMB}`, not `"${THUMB}"`), because the token may already have been spliced into a string (e.g `tmux display-message "Copied {}"`), and it's impossible (or at least exceedingly difficult) to determine the correct quoting level.

The previous approach of literally splicing the text into the command causes all kinds of harmful escaping issues that the user cannot reasonable avoid.

For example, imagine some pattern matched the text `"foo;rm *"` and the user's command was an innocuous `echo {}`. With literal splicing, we would run the command `"echo foo;rm *"`. That's BAD. Without splicing, instead we execute "echo ${THUMB}" which does mostly the right thing regardless the contents of the text. (At worst, bash will word-separate the unquoted variable; but it won't _execute_ those words in common scenarios).

Ideally user commands would just use `"${THUMB}"` to begin with rather than having any sort of ad-hoc string splicing here at all, and then they could specify the quoting they want, but that would break backwards compatibility.

----

## Compatibility:

This will copy the wrong text (just the literal `${THUMB}`) if user commands had previously surrounded the `{}` in single quotes. However, it's trivially fixed:
```diff
- set -g @thumbs-command "tmux set-buffer '{}'"
+ set -g @thumbs-command 'tmux set-buffer "{}"'
```

This will no longer break on patterns that have quotes in them.