### PR TITLE
fix regexp parsing from tmux config

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ Add extra patterns to match. This parameter can have multiple instances.
 For example:
 
 ```
-set -g @thumbs-regexp-1 '[a-z]+@[a-z]+.com' # Match emails
-set -g @thumbs-regexp-2 '[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:' # Match MAC addresses
+set -g @thumbs-regexp-1 [a-z]+@[a-z]+.com # Match emails
+set -g @thumbs-regexp-2 [a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}: # Match MAC addresses
+set -g @thumbs-regexp-3 Vlan\\d+ # match Vlan interface on network devices
 ```
 
 ### @thumbs-command

--- a/README.md
+++ b/README.md
@@ -167,9 +167,11 @@ Add extra patterns to match. This parameter can have multiple instances.
 For example:
 
 ```
-set -g @thumbs-regexp-1 [a-z]+@[a-z]+.com # Match emails
-set -g @thumbs-regexp-2 [a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}: # Match MAC addresses
-set -g @thumbs-regexp-3 Vlan\\d+ # match Vlan interface on network devices
+set -g @thumbs-regexp-1 '[a-z]+@[a-z]+.com' # Match emails
+set -g @thumbs-regexp-2 '[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:' # Match MAC addresses
+set -g @thumbs-regexp-3 'Vlan\d+' # match Vlan interface on network devices
+set -g @thumbs-regexp-4 "Vlan\\d+" # alternative method of defining regexp 
+set -g @thumbs-regexp-5 Vlan\\d+ # alternative method of defining regexp 
 ```
 
 ### @thumbs-command

--- a/src/swapper.rs
+++ b/src/swapper.rs
@@ -136,7 +136,7 @@ impl<'a> Swapper<'a> {
     let options = self.executor.execute(params);
     let lines: Vec<&str> = options.split('\n').collect();
 
-    let pattern = Regex::new(r#"@thumbs-([\w\-0-9]+) "?(\w+)"?"#).unwrap();
+    let pattern = Regex::new(r#"@thumbs-([\w\-0-9]+)\s+(.+)"#).unwrap();
 
     let args = lines
       .iter()
@@ -166,7 +166,7 @@ impl<'a> Swapper<'a> {
           }
 
           if name.starts_with("regexp") {
-            return vec!["--regexp".to_string(), format!("'{}'", value)];
+            return vec!["--regexp".to_string(), format!("'{}'", value.replace("\\\\", "\\"))];
           }
 
           vec![]

--- a/src/swapper.rs
+++ b/src/swapper.rs
@@ -136,7 +136,9 @@ impl<'a> Swapper<'a> {
     let options = self.executor.execute(params);
     let lines: Vec<&str> = options.split('\n').collect();
 
-    let pattern = Regex::new(r#"@thumbs-([\w\-0-9]+)\s+(.+)"#).unwrap();
+    //let pattern = Regex::new(r#"@thumbs-([\w\-0-9]+)\s+(.+)"#).unwrap();
+    let pattern =
+      Regex::new(r#"@thumbs-([\w\-0-9]+)\s+"?([\w\d\[\{\(\-\+/\\\.,\|=\)\}\]!@#\$%\^&~`:<>\?;'\*]+)"?$"#).unwrap();
 
     let args = lines
       .iter()

--- a/src/swapper.rs
+++ b/src/swapper.rs
@@ -136,9 +136,7 @@ impl<'a> Swapper<'a> {
     let options = self.executor.execute(params);
     let lines: Vec<&str> = options.split('\n').collect();
 
-    //let pattern = Regex::new(r#"@thumbs-([\w\-0-9]+)\s+(.+)"#).unwrap();
-    let pattern =
-      Regex::new(r#"@thumbs-([\w\-0-9]+)\s+"?([\w\d\[\{\(\-\+/\\\.,\|=\)\}\]!@#\$%\^&~`:<>\?;'\*]+)"?$"#).unwrap();
+    let pattern = Regex::new(r#"@thumbs-([\w\-0-9]+)\s+"?([^"]+)"?$"#).unwrap();
 
     let args = lines
       .iter()


### PR DESCRIPTION
This is to address #56 
Alright, here is the problem. `\w+` does not match `\\` `[`, etc. Also it can be a valid requirement to match `"`, so it is just easier to treat whatever comes after `set -g @thumbs-regexp-N ` as the regexp that needs matching.

When not using any quotes or using double quotes, the user needs to define regexp with `\\`, when using single quotes, single `\` gets the job done.


In this case a regexp would look something like this:

```
set -g @thumbs-regexp-1 "Vlan\\d+"
```

or 

```
set -g @thumbs-regexp-1 'Vlan\d+'
```

or without quotes

```
set -g @thumbs-regexp-1 Vlan\\d+
```


When this gets passed to `tmux-thumbs` it'll read as `Vlan\\d+` which'll get passed to `thumbs` as `Vlan\\\\d+` thus it needs to be replaced.

