### PR TITLE
Add hex color support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ version = "0.5.0"
 dependencies = [
  "base64",
  "clap",
+ "lazy_static",
  "regex",
  "termion",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ regex = "1.3.1"
 clap = "2.33.0"
 base64 = "0.11.0"
 unicode-width = "0.1.7"
+lazy_static = "1.4.0"
 
 [[bin]]
 name = "thumbs"

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ set -g @thumbs-osc52 1
 
 #### Colors
 
-This is the list of available colors:
+This is the list of predefined colors:
 
 - black
 - red
@@ -307,6 +307,8 @@ This is the list of available colors:
 - cyan
 - white
 - default
+
+There is also support for using hex colors in the form of `#RRGGBB`.
 
 #### Alphabets
 

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,16 +1,16 @@
 use termion::color;
 
-pub fn get_color(color_name: &str) -> Box<&dyn color::Color> {
+pub fn get_color(color_name: &str) -> Box<dyn color::Color> {
   match color_name {
-    "black" => Box::new(&color::Black),
-    "red" => Box::new(&color::Red),
-    "green" => Box::new(&color::Green),
-    "yellow" => Box::new(&color::Yellow),
-    "blue" => Box::new(&color::Blue),
-    "magenta" => Box::new(&color::Magenta),
-    "cyan" => Box::new(&color::Cyan),
-    "white" => Box::new(&color::White),
-    "default" => Box::new(&color::Reset),
+    "black" => Box::new(color::Black),
+    "red" => Box::new(color::Red),
+    "green" => Box::new(color::Green),
+    "yellow" => Box::new(color::Yellow),
+    "blue" => Box::new(color::Blue),
+    "magenta" => Box::new(color::Magenta),
+    "cyan" => Box::new(color::Cyan),
+    "white" => Box::new(color::White),
+    "default" => Box::new(color::Reset),
     _ => panic!("Unknown color: {}", color_name),
   }
 }
@@ -21,7 +21,7 @@ mod tests {
 
   #[test]
   fn match_color() {
-    let text1 = println!("{}{}", color::Fg(*get_color("green")), "foo");
+    let text1 = println!("{}{}", color::Fg(&*get_color("green")), "foo");
     let text2 = println!("{}{}", color::Fg(color::Green), "foo");
 
     assert_eq!(text1, text2);
@@ -30,6 +30,6 @@ mod tests {
   #[test]
   #[should_panic]
   fn no_match_color() {
-    println!("{}{}", color::Fg(*get_color("wat")), "foo");
+    println!("{}{}", color::Fg(&*get_color("wat")), "foo");
   }
 }

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,6 +1,19 @@
+use regex::Regex;
 use termion::color;
 
 pub fn get_color(color_name: &str) -> Box<dyn color::Color> {
+  lazy_static! {
+    static ref RGB: Regex = Regex::new(r"#([[:xdigit:]]{2})([[:xdigit:]]{2})([[:xdigit:]]{2})").unwrap();
+  }
+
+  if let Some(captures) = RGB.captures(color_name) {
+    let r = u8::from_str_radix(captures.get(1).unwrap().as_str(), 16).unwrap();
+    let g = u8::from_str_radix(captures.get(2).unwrap().as_str(), 16).unwrap();
+    let b = u8::from_str_radix(captures.get(3).unwrap().as_str(), 16).unwrap();
+
+    return Box::new(color::Rgb(r, g, b));
+  }
+
   match color_name {
     "black" => Box::new(color::Black),
     "red" => Box::new(color::Red),
@@ -25,6 +38,20 @@ mod tests {
     let text2 = println!("{}{}", color::Fg(color::Green), "foo");
 
     assert_eq!(text1, text2);
+  }
+
+  #[test]
+  fn parse_rgb() {
+    let text1 = println!("{}{}", color::Fg(&*get_color("#1b1cbf")), "foo");
+    let text2 = println!("{}{}", color::Fg(color::Rgb(27, 28, 191)), "foo");
+
+    assert_eq!(text1, text2);
+  }
+
+  #[test]
+  #[should_panic]
+  fn parse_invalid_rgb() {
+    println!("{}{}", color::Fg(&*get_color("#1b1cbj")), "foo");
   }
 
   #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate lazy_static;
 extern crate base64;
 extern crate clap;
 extern crate termion;

--- a/src/view.rs
+++ b/src/view.rs
@@ -17,12 +17,12 @@ pub struct View<'a> {
   contrast: bool,
   position: &'a str,
   matches: Vec<state::Match<'a>>,
-  select_foreground_color: Box<&'a dyn color::Color>,
-  select_background_color: Box<&'a dyn color::Color>,
-  foreground_color: Box<&'a dyn color::Color>,
-  background_color: Box<&'a dyn color::Color>,
-  hint_background_color: Box<&'a dyn color::Color>,
-  hint_foreground_color: Box<&'a dyn color::Color>,
+  select_foreground_color: Box<dyn color::Color>,
+  select_background_color: Box<dyn color::Color>,
+  foreground_color: Box<dyn color::Color>,
+  background_color: Box<dyn color::Color>,
+  hint_background_color: Box<dyn color::Color>,
+  hint_foreground_color: Box<dyn color::Color>,
 }
 
 enum CaptureEvent {
@@ -38,12 +38,12 @@ impl<'a> View<'a> {
     unique: bool,
     contrast: bool,
     position: &'a str,
-    select_foreground_color: Box<&'a dyn color::Color>,
-    select_background_color: Box<&'a dyn color::Color>,
-    foreground_color: Box<&'a dyn color::Color>,
-    background_color: Box<&'a dyn color::Color>,
-    hint_foreground_color: Box<&'a dyn color::Color>,
-    hint_background_color: Box<&'a dyn color::Color>,
+    select_foreground_color: Box<dyn color::Color>,
+    select_background_color: Box<dyn color::Color>,
+    foreground_color: Box<dyn color::Color>,
+    background_color: Box<dyn color::Color>,
+    hint_foreground_color: Box<dyn color::Color>,
+    hint_background_color: Box<dyn color::Color>,
   ) -> View<'a> {
     let matches = state.matches(reverse, unique);
     let skip = if reverse { matches.len() - 1 } else { 0 };
@@ -119,8 +119,8 @@ impl<'a> View<'a> {
       print!(
         "{goto}{background}{foregroud}{text}{resetf}{resetb}",
         goto = cursor::Goto(offset + 1, mat.y as u16 + 1),
-        foregroud = color::Fg(**selected_color),
-        background = color::Bg(**selected_background_color),
+        foregroud = color::Fg(&**selected_color),
+        background = color::Bg(&**selected_background_color),
         resetf = color::Fg(color::Reset),
         resetb = color::Bg(color::Reset),
         text = &text
@@ -140,8 +140,8 @@ impl<'a> View<'a> {
         print!(
           "{goto}{background}{foregroud}{text}{resetf}{resetb}",
           goto = cursor::Goto(final_position as u16 + 1, mat.y as u16 + 1),
-          foregroud = color::Fg(*self.hint_foreground_color),
-          background = color::Bg(*self.hint_background_color),
+          foregroud = color::Fg(&*self.hint_foreground_color),
+          background = color::Bg(&*self.hint_background_color),
           resetf = color::Fg(color::Reset),
           resetb = color::Bg(color::Reset),
           text = &text


### PR DESCRIPTION
This PR adds support for parsing hex colors, based on discussion in issue #65 

Feel free to suggest changes. My first few lines in Rust.