### PR TITLE
Fix hint position when using contrast=1 and position off_left

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -129,7 +129,7 @@ impl<'a> View<'a> {
       if let Some(ref hint) = mat.hint {
         let extra_position = match self.position {
           "right" => text.width_cjk() - hint.len(),
-          "off_left" => 0 - hint.len(),
+          "off_left" => 0 - hint.len() - if self.contrast { 2 } else { 0 },
           "off_right" => text.width_cjk(),
           _ => 0,
         };


### PR DESCRIPTION
"thumbs mode" off:
![original](https://user-images.githubusercontent.com/45585143/104854470-a1308a00-58e5-11eb-8a9f-a673ed4f2e43.png)

"thumbs mode" on **without** this fix:
![before](https://user-images.githubusercontent.com/45585143/104854593-5bc08c80-58e6-11eb-8d1a-81e99a216277.png)

"thumbs mode" on **with** this fix:
![after](https://user-images.githubusercontent.com/45585143/104854597-62e79a80-58e6-11eb-9fd0-e720cea7ff8b.png)
