### PR TITLE
add missing multi-command configuration of tmux mode

### DIFF
--- a/src/swapper.rs
+++ b/src/swapper.rs
@@ -179,6 +179,8 @@ impl<'a> Swapper<'a> {
             "hint-fg-color",
             "select-fg-color",
             "select-bg-color",
+            "multi-fg-color",
+            "multi-bg-color",
           ];
 
           if string_params.iter().any(|&x| x == name) {

--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -33,6 +33,7 @@ function add-param() {
 
 add-param command        string
 add-param upcase-command string
+add-param multi-command  string
 add-param osc52          boolean
 
 "${CURRENT_DIR}/target/release/tmux-thumbs" "${PARAMS[@]}" || true


### PR DESCRIPTION
multi-command related configuration is missing in current version.
This PR add this configuration:
* add "thumbs-multi-command" support
* add "thumbs-multi-bg-color" and "thumbs-multi-fg-color" support