### PR TITLE
Enable single quotes in @thumbs-regexp-N.

### DIFF
--- a/src/swapper.rs
+++ b/src/swapper.rs
@@ -188,7 +188,7 @@ impl<'a> Swapper<'a> {
           }
 
           if name.starts_with("regexp") {
-            return vec!["--regexp".to_string(), format!("'{}'", value.replace("\\\\", "\\"))];
+            return vec!["--regexp".to_string(), format!("'{}'", value.replace("\\\\", "\\").replace("'", "'\"'\"'"))];
           }
 
           vec![]


### PR DESCRIPTION
Fix the bug happened when a pattern has single quotes in it, for example, a pattern `'[^']+'` won't work without this fix. Currently, the `--regexp` parameters are constructed surrounded by single quotes, but when it comes to a pattern with single quotes in it, this plugin stops working.