### PR TITLE
Display build instructions if tmux-thumbs executable is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,14 @@ You can add this line to your list of [TPM](https://github.com/tmux-plugins/tpm)
 set -g @plugin 'fcsonline/tmux-thumbs'
 ```
 
-To be able to install the plugin just hit <kbd>prefix</kbd> + <kbd>I</kbd>. You should now be able to use
-the plugin!
+To install the plugin just hit <kbd>prefix</kbd> + <kbd>I</kbd>, then compile it with [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html):
+
+```
+cd ~/.tmux/plugins/tmux-thumbs
+cargo build --release
+```
+
+You should now be able to use the plugin!
 
 ## Configuration
 

--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -2,6 +2,7 @@
 set -Eeu -o pipefail
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BIN="${CURRENT_DIR}/target/release/tmux-thumbs"
 
 function get-opt-value() {
   tmux show -vg "@thumbs-${1}" 2> /dev/null
@@ -36,4 +37,10 @@ add-param upcase-command string
 add-param multi-command  string
 add-param osc52          boolean
 
-"${CURRENT_DIR}/target/release/tmux-thumbs" "${PARAMS[@]}" || true
+if [ -x "${BIN}" ]; then
+  "${BIN}" "${PARAMS[@]}"
+else
+  tmux display-message -p "\"${BIN}\" not found or not executable, you must build it manually:
+  
+  cd \"${CURRENT_DIR}\" && cargo build --release"
+fi


### PR DESCRIPTION
Without this, nothing happens if tmux-thumbs executable is missing.

Relates to https://github.com/fcsonline/tmux-thumbs/issues/53