### PR TITLE
Add release workflow with musl static build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+      
+  workflow_dispatch:
+
+jobs:
+    release:
+      name: release
+      runs-on: ubuntu-latest
+      steps:
+        - name: checkout
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+        - name: build
+          uses: sassman/rust-deb-builder@v1.57.0
+          with:
+             target: x86_64-unknown-linux-musl
+        - name: package
+          run: |
+            cd "$GITHUB_WORKSPACE"
+            mkdir -p package
+            mkdir -p package/target/release
+            cp -v tmux-thumbs.sh tmux-thumbs.tmux package/
+            cp -v target/x86_64-unknown-linux-musl/release/thumbs package/target/release
+            cp -v target/x86_64-unknown-linux-musl/release/tmux-thumbs package/target/release
+            tar czvf tmux-thumbs.x86_64-musl.tar.gz package/*
+        - name: create_release
+          uses: ncipollo/release-action@v1.9.0
+          with:
+            artifactErrorsFailBuild: true
+            artifacts: "tmux-thumbs.x86_64-musl.tar.gz"


### PR DESCRIPTION
Adds a github action to build the rust binaries (using static linking to the musl library) for those who cannot build the rust dependency on their machines directly.