### PR TITLE
Support higher arity expansion in hint generation

### DIFF
--- a/src/alphabets.rs
+++ b/src/alphabets.rs
@@ -37,30 +37,36 @@ impl<'a> Alphabet<'a> {
   pub fn hints(&self, matches: usize) -> Vec<String> {
     let letters: Vec<String> = self.letters.chars().map(|s| s.to_string()).collect();
 
-    let mut expansion = letters.clone();
-    let mut expanded: Vec<String> = Vec::new();
+    if letters.len() <= 1 {
+      return letters;
+    }
+
+    let mut expansion: Vec<String> = letters.clone();
+    let mut expand_idx = expansion.len() - 1;
 
     loop {
-      if expansion.len() + expanded.len() >= matches {
-        break;
-      }
-      if expansion.is_empty() {
+      if expansion.len() >= matches {
         break;
       }
 
-      let prefix = expansion.pop().expect("Ouch!");
+      let prefix = expansion.remove(expand_idx);
+
       let sub_expansion: Vec<String> = letters
         .iter()
-        .take(matches - expansion.len() - expanded.len())
+        .take(matches - expansion.len())
         .map(|s| prefix.clone() + s)
         .collect();
 
-      expanded.splice(0..0, sub_expansion);
+      expansion.splice(expand_idx..expand_idx, sub_expansion.clone());
+
+      if expand_idx == 0 {
+        expand_idx = expansion.len() - 1;
+      } else {
+        expand_idx -= 1;
+      }
     }
 
-    expansion = expansion.iter().take(matches - expanded.len()).cloned().collect();
-    expansion.append(&mut expanded);
-    expansion
+    expansion.iter().take(matches).cloned().collect()
   }
 }
 
@@ -93,16 +99,16 @@ mod tests {
   }
 
   #[test]
-  fn composed_matches_multiple() {
+  fn composed_matches_two_arity() {
     let alphabet = Alphabet::new("abcd");
     let hints = alphabet.hints(8);
     assert_eq!(hints, ["a", "b", "ca", "cb", "da", "db", "dc", "dd"]);
   }
 
   #[test]
-  fn composed_matches_max() {
+  fn composed_matches_three_arity() {
     let alphabet = Alphabet::new("ab");
-    let hints = alphabet.hints(8);
-    assert_eq!(hints, ["aa", "ab", "ba", "bb"]);
+    let hints = alphabet.hints(7);
+    assert_eq!(hints, ["aa", "aba", "abb", "baa", "bab", "bba", "bbb"]);
   }
 }


### PR DESCRIPTION
When using `qwerty-homerow`, only 9 chars are available generating maximum of 81 combinations for hints.

In some cases, this can happen, and there is nothing user can do but to change alphabet to `qwerty` or alike.

This pull request tries sacrifice shorter hint length to full coverage of all candidates. It has basically the same algorithm, but continue to generate more than 2 chars when not enough.

I'm not quite sure if you'd like this change, hope you can share your opinion.

Tridactyl has a better [algorithm](https://github.com/tridactyl/tridactyl/blob/dbd5bd42990260c38ce0b482133a1e292891c76e/src/content/hinting.ts#L537) to achieve this, but is harder to implement.

A comparision of generated hints:
```
"aa", "as", "ad", "af", "aj", "ak", "al", "ag", "ah", "sa", "ss", "sd", "sf", "sj", "sk", "sl", "sg", "sh", "da", "ds", "dd", "df", "dj", "dk", "dl", "dg", "dh", "fa", "fs", "fd", "ff", "fj", "fk", "fl", "fg", "fh", "ja", "js", "jd", "jf", "jj", "jk", "jl", "jg", "jh", "ka", "ks", "kd", "kf", "kj", "kk", "kl", "kg", "kh", "la", "ls", "ld", "lf", "lj", "lk", "ll", "lg", "lh", "ga", "gs", "gd", "gf", "gj", "gk", "gl", "gg", "gh", "ha", "hs", "hd", "hf", "hj", "hk", "hl", "hg", "hh"
```

```
"aa", "as", "ad", "af", "aj", "ak", "al", "ag", "ah", "sa", "ss", "sd", "sf", "sj", "sk", "sl", "sg", "sh", "da", "ds", "dd", "df", "dj", "dk", "dl", "dg", "dh", "fa", "fs", "fd", "ff", "fj", "fk", "fl", "fg", "fh", "ja", "js", "jd", "jf", "jj", "jk", "jl", "jg", "jh", "ka", "ks", "kd", "kf", "kj", "kk", "kl", "kg", "kh", "la", "ls", "ld", "lf", "lj", "lk", "ll", "lg", "lh", "ga", "gs", "gd", "gf", "gj", "gk", "gl", "gg", "gh", "ha", "hs", "hd", "hf", "hj", "hk", "hla", "hls", "hld", "hlf", "hga", "hgs", "hgd", "hgf", "hgj", "hgk", "hgl", "hgg", "hgh", "hha", "hhs", "hhd", "hhf", "hhj", "hhk", "hhl", "hhg", "hhh"
```
