### PR TITLE
Fix installation bug in tag 0.7.0

### DIFF
--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -4,7 +4,7 @@ set -Eeu -o pipefail
 # Setup env variables to be compatible with compiled and bundled installations
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -d .git ]; then
+if [ -d ${CURRENT_DIR}/.git ]; then
   RELEASE_DIR="${CURRENT_DIR}/target/release"
 else
   RELEASE_DIR=${CURRENT_DIR}


### PR DESCRIPTION
bbf677fda318 ("Improve the matrix of releases") included a fix to cope
with compiled and bundled installations.  However, the check for the
.git/ repository is done from where tmux is launched, not where
tmux-thumbs is installed, so RELEASE_DIR is not properly set always.
This leads to tmux-thumbs always trying to install itself when installed
via tmux-plugin-manager.