### PR TITLE
Fix installation when '.git' is a file (submodule)

### DIFF
--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -4,7 +4,7 @@ set -Eeu -o pipefail
 # Setup env variables to be compatible with compiled and bundled installations
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -d ${CURRENT_DIR}/.git ]; then
+if ([ -d ${CURRENT_DIR}/.git ] || [ -f ${CURRENT_DIR}/.git ]); then
   RELEASE_DIR="${CURRENT_DIR}/target/release"
 else
   RELEASE_DIR=${CURRENT_DIR}


### PR DESCRIPTION
this happens if 'git submodule add' is used

![image](https://user-images.githubusercontent.com/19471811/152051807-7461d2a0-66ac-4c05-b2d3-4c27690acf9d.png)
