### PR TITLE
Add a new flow to detect plugin updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ You can add this line to your list of [TPM](https://github.com/tmux-plugins/tpm)
 
 ```
 set -g @plugin 'fcsonline/tmux-thumbs'
+
+run-shell ~/.tmux/plugins/tmux-thumbs/tmux-thumbs.tmux
 ```
 
 To be able to install the plugin just hit <kbd>prefix</kbd> + <kbd>I</kbd>. You should now be able to use

--- a/tmux-thumbs-install.sh
+++ b/tmux-thumbs-install.sh
@@ -17,37 +17,58 @@ cat << EOF
   ░░█████  █████░███ █████ ░░████████ █████ █████             ░░█████  ████ █████ ░░████████ █████░███ █████ ████████  ██████
    ░░░░░  ░░░░░ ░░░ ░░░░░   ░░░░░░░░ ░░░░░ ░░░░░               ░░░░░  ░░░░ ░░░░░   ░░░░░░░░ ░░░░░ ░░░ ░░░░░ ░░░░░░░░  ░░░░░░
 
-
-
-It looks like this is the first time you are executing tmux-thumbs
-because the binary is not present.
-
-We are going to proceed with the installation. If you have Rust preinstalled, we will try to
-compile the binary from source. Otherwise, a prebuild binary for your platform will be used.
-
-Do you want to continue?
-
-Press any key to continue...
 EOF
+
+
+if [ "${1:-install}" == "update" ]; then
+
+cat << EOF
+  ⚠️  UPDATE! ⚠️
+
+  It looks like you got a new version of tmux-thumbs repository but
+  the binary version is not in sync.
+
+  We are going to proceed with the new installation.
+
+  Do you want to continue?
+
+  Press any key to continue...
+EOF
+
+else
+
+cat << EOF
+  It looks like this is the first time you are executing tmux-thumbs
+  because the binary is not present.
+
+  We are going to proceed with the installation. If you have Rust preinstalled, we will try to
+  compile the binary from source. Otherwise, a prebuild binary for your platform will be used.
+
+  Do you want to continue?
+
+  Press any key to continue...
+EOF
+
+fi
 
 read -rs -n 1
 
 if ! [ -x "$(command -v cargo)" ]; then
   platform="$(uname -s) $(uname -m)"
 
-  echo "Rust is not installed! Trying to install ${platform} binary..."
+  echo "  Rust is not installed! Trying to install ${platform} binary..."
 
   sources=$(curl -s "https://api.github.com/repos/fcsonline/tmux-thumbs/releases/latest" | grep browser_download_url)
 
   case $platform in
     "Darwin x86_64")
       url=$(echo "${sources}" | grep -o 'https://.*darwin.zip' | uniq)
-      curl -L "${url}" | bsdtar -xf - thumbs tmux-thumbs
+      curl -sL "${url}" | bsdtar -xf - thumbs tmux-thumbs
 
       ;;
     "Linux x86_64")
       url=$(echo "${sources}" | grep -o 'https://.*linux-musl.tar.gz' | uniq)
-      curl -L "${url}" | tar -zxf - thumbs tmux-thumbs
+      curl -sL "${url}" | tar -zxf - thumbs tmux-thumbs
 
       ;;
     *)
@@ -58,17 +79,16 @@ if ! [ -x "$(command -v cargo)" ]; then
 
   chmod +x thumbs tmux-thumbs
   mkdir -p target/release
-  mv thumbs target/release
-  mv tmux-thumbs target/release
+  mv thumbs tmux-thumbs target/release
 else
-  echo 'Compiling tmux-thumbs, be patient:'
+  echo '  Compiling tmux-thumbs, be patient:'
   cargo build --release --target-dir=target
 fi
 
 cat << EOF
-Installation complete! 💯
+  Installation complete! 💯
 
-Press any key to close this pane...
+  Press any key to close this pane...
 EOF
 
 read -rs -n 1

--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -Eeu -o pipefail
 
+VERSION=$(grep 'version =' Cargo.toml | grep -oe "[0-9]\+.[0-9]\+.[0-9]\+")
+
 # Setup env variables to be compatible with compiled and bundled installations
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 RELEASE_DIR="${CURRENT_DIR}/target/release"
@@ -10,6 +12,9 @@ TMUX_THUMBS_BINARY="${RELEASE_DIR}/tmux-thumbs"
 
 if [ ! -f "$THUMBS_BINARY" ]; then
   tmux split-window "cd ${CURRENT_DIR} && bash ./tmux-thumbs-install.sh"
+  exit
+elif [[ $(${THUMBS_BINARY} --version) != "thumbs ${VERSION}"  ]]; then
+  tmux split-window "cd ${CURRENT_DIR} && bash ./tmux-thumbs-install.sh update"
   exit
 fi
 


### PR DESCRIPTION
If you update the plugin with TPM, the `thumbs` binary can get out of
sync. So we need to check the version before proceed.

If there is a version mismatch, then we run a new install in "update"
mode.