### PR TITLE
Changing grep check for OpenBSD compatibility

### DIFF
--- a/tmux-thumbs.sh
+++ b/tmux-thumbs.sh
@@ -7,7 +7,7 @@ RELEASE_DIR="${CURRENT_DIR}/target/release"
 
 THUMBS_BINARY="${RELEASE_DIR}/thumbs"
 TMUX_THUMBS_BINARY="${RELEASE_DIR}/tmux-thumbs"
-VERSION=$(grep 'version =' "${CURRENT_DIR}/Cargo.toml" | grep -oe "[0-9]\+.[0-9]\+.[0-9]\+")
+VERSION=$(grep 'version =' "${CURRENT_DIR}/Cargo.toml" | grep -o "\".*\"" | sed 's/"//g')
 
 if [ ! -f "$THUMBS_BINARY" ]; then
   tmux split-window "cd ${CURRENT_DIR} && bash ./tmux-thumbs-install.sh"


### PR DESCRIPTION
The different implementations of `grep` that exist in Linux and OpenBSD
makes the tmux-thumbs script to crash. Changing the command to be
compatible.