### PR TITLE
Add tmux note to keybinding for list-keys

### DIFF
--- a/tmux-thumbs.tmux
+++ b/tmux-thumbs.tmux
@@ -8,4 +8,4 @@ THUMBS_KEY="$(tmux show-option -gqv @thumbs-key)"
 THUMBS_KEY=${THUMBS_KEY:-$DEFAULT_THUMBS_KEY}
 
 tmux set-option -ag command-alias "thumbs-pick=run-shell -b ${CURRENT_DIR}/tmux-thumbs.sh"
-tmux bind-key "${THUMBS_KEY}" thumbs-pick
+tmux bind-key -N "Activate tmux thumbs picker" "${THUMBS_KEY}" thumbs-pick


### PR DESCRIPTION
This PR simply adds a -N note so that the chosen key binding appears in `tmux list-keys` / `<prefix> + ?` and "Describe key binding" `<prefix> + /`, which is useful when you have a lot of custom keybindings.