### PR TITLE
feat: allow multiline matching and double quotes in regexp expression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,12 +59,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -159,10 +174,10 @@ version = "0.8.0"
 dependencies = [
  "base64",
  "clap",
+ "itertools",
  "lazy_static",
  "regex",
  "termion",
- "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ termion = "1.5.6"
 regex = "1.7.1"
 clap = "2.34.0"
 base64 = "0.13.1"
-unicode-width = "0.1.10"
 lazy_static = "1.4.0"
+itertools = "0.10.5"
 
 [[bin]]
 name = "thumbs"

--- a/src/alphabets.rs
+++ b/src/alphabets.rs
@@ -44,18 +44,17 @@ impl<'a> Alphabet<'a> {
       if expansion.len() + expanded.len() >= matches {
         break;
       }
-      if expansion.is_empty() {
+      if let Some(prefix) = expansion.pop() {
+        let sub_expansion: Vec<String> = letters
+          .iter()
+          .take(matches - expansion.len() - expanded.len())
+          .map(|s| prefix.clone() + s)
+          .collect();
+
+        expanded.splice(0..0, sub_expansion);
+      } else {
         break;
       }
-
-      let prefix = expansion.pop().expect("Ouch!");
-      let sub_expansion: Vec<String> = letters
-        .iter()
-        .take(matches - expansion.len() - expanded.len())
-        .map(|s| prefix.clone() + s)
-        .collect();
-
-      expanded.splice(0..0, sub_expansion);
     }
 
     expansion = expansion.iter().take(matches - expanded.len()).cloned().collect();

--- a/src/alphabets.rs
+++ b/src/alphabets.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-const ALPHABETS: [(&'static str, &'static str); 22] = [
+const ALPHABETS: [(&str, &str); 22] = [
   ("numeric", "1234567890"),
   ("abcd", "abcd"),
   ("qwerty", "asdfqwerzxcvjklmiuopghtybn"),
@@ -69,7 +69,7 @@ pub fn get_alphabet(alphabet_name: &str) -> Alphabet {
 
   alphabets
     .get(alphabet_name)
-    .expect(format!("Unknown alphabet: {}", alphabet_name).as_str()); // FIXME
+    .unwrap_or_else(|| panic!("Unknown alphabet: {}", alphabet_name)); // FIXME
 
   Alphabet::new(alphabets[alphabet_name])
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,14 +171,6 @@ fn main() {
 
   handle.read_to_string(&mut output).unwrap();
 
-  if output.ends_with("\r\n") {
-    output.pop();
-    output.pop();
-  } else if output.ends_with('\n') {
-    output.pop();
-    output = output.replace('\n', "\r\n");
-  };
-
   let mut state = state::State::new(output.as_str(), alphabet, &regexp);
 
   let selected = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,9 +174,9 @@ fn main() {
   if output.ends_with("\r\n") {
     output.pop();
     output.pop();
-  } else if output.ends_with("\n") {
+  } else if output.ends_with('\n') {
     output.pop();
-    output = output.replace("\n", "\r\n");
+    output = output.replace('\n', "\r\n");
   };
 
   let mut state = state::State::new(output.as_str(), alphabet, &regexp);
@@ -229,7 +229,7 @@ fn main() {
         .open(target)
         .expect("Unable to open the target file");
 
-      file.write(output.as_bytes()).unwrap();
+      file.write_all(output.as_bytes()).unwrap();
     } else {
       print!("{}", output);
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -90,7 +90,10 @@ impl<'a> State<'a> {
       .collect::<Vec<_>>();
 
     // This order determines the priority of pattern matching
-    let all_patterns = [exclude_patterns, custom_patterns, patterns].concat();
+    let all_patterns = [
+      exclude_patterns,
+      if custom_patterns.is_empty() { patterns } else { custom_patterns },
+    ].concat();
 
     let mut chunk: &str = self.output;
     let mut offset: usize = 0;

--- a/src/state.rs
+++ b/src/state.rs
@@ -193,15 +193,11 @@ impl<'a> State<'a> {
 mod tests {
   use super::*;
 
-  fn split(output: &str) -> Vec<&str> {
-    output.split("\n").collect::<Vec<&str>>()
-  }
-
   #[test]
   fn match_reverse() {
-    let lines = split("lorem 127.0.0.1 lorem 255.255.255.255 lorem 127.0.0.1 lorem");
+    let output = "lorem 127.0.0.1 lorem 255.255.255.255 lorem 127.0.0.1 lorem";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 3);
     assert_eq!(results.first().unwrap().hint.clone().unwrap(), "a");
@@ -210,9 +206,9 @@ mod tests {
 
   #[test]
   fn match_unique() {
-    let lines = split("lorem 127.0.0.1 lorem 255.255.255.255 lorem 127.0.0.1 lorem");
+    let output = "lorem 127.0.0.1 lorem 255.255.255.255 lorem 127.0.0.1 lorem";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, true);
+    let results = State::new(output, "abcd", &custom).matches(false, true);
 
     assert_eq!(results.len(), 3);
     assert_eq!(results.first().unwrap().hint.clone().unwrap(), "a");
@@ -221,9 +217,9 @@ mod tests {
 
   #[test]
   fn match_docker() {
-    let lines = split("latest sha256:30557a29d5abc51e5f1d5b472e79b7e296f595abcf19fe6b9199dbbc809c6ff4 20 hours ago");
+    let output = "latest sha256:30557a29d5abc51e5f1d5b472e79b7e296f595abcf19fe6b9199dbbc809c6ff4 20 hours ago";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 1);
     assert_eq!(
@@ -234,9 +230,9 @@ mod tests {
 
   #[test]
   fn match_bash() {
-    let lines = split("path: [32m/var/log/nginx.log[m\npath: [32mtest/log/nginx-2.log:32[mfolder/.nginx@4df2.log");
+    let output = "path: [32m/var/log/nginx.log[m\npath: [32mtest/log/nginx-2.log:32[mfolder/.nginx@4df2.log";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 3);
     assert_eq!(results.get(0).unwrap().text, "/var/log/nginx.log");
@@ -246,227 +242,227 @@ mod tests {
 
   #[test]
   fn match_paths() {
-    let lines = split("Lorem /tmp/foo/bar_lol, lorem\n Lorem /var/log/boot-strap.log lorem ../log/kern.log lorem");
+    let output = "Lorem /tmp/foo/bar_lol, lorem\n Lorem /var/log/boot-strap.log lorem ../log/kern.log lorem";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 3);
-    assert_eq!(results.get(0).unwrap().text.clone(), "/tmp/foo/bar_lol");
-    assert_eq!(results.get(1).unwrap().text.clone(), "/var/log/boot-strap.log");
-    assert_eq!(results.get(2).unwrap().text.clone(), "../log/kern.log");
+    assert_eq!(results.get(0).unwrap().text, "/tmp/foo/bar_lol");
+    assert_eq!(results.get(1).unwrap().text, "/var/log/boot-strap.log");
+    assert_eq!(results.get(2).unwrap().text, "../log/kern.log");
   }
 
   #[test]
   fn match_routes() {
-    let lines = split("Lorem /app/routes/$routeId/$objectId, lorem\n Lorem /app/routes/$sectionId");
+    let output = "Lorem /app/routes/$routeId/$objectId, lorem\n Lorem /app/routes/$sectionId";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 2);
-    assert_eq!(results.get(0).unwrap().text.clone(), "/app/routes/$routeId/$objectId");
-    assert_eq!(results.get(1).unwrap().text.clone(), "/app/routes/$sectionId");
+    assert_eq!(results.get(0).unwrap().text, "/app/routes/$routeId/$objectId");
+    assert_eq!(results.get(1).unwrap().text, "/app/routes/$sectionId");
   }
 
   #[test]
   fn match_home() {
-    let lines = split("Lorem ~/.gnu/.config.txt, lorem");
+    let output = "Lorem ~/.gnu/.config.txt, lorem";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 1);
-    assert_eq!(results.get(0).unwrap().text.clone(), "~/.gnu/.config.txt");
+    assert_eq!(results.get(0).unwrap().text, "~/.gnu/.config.txt");
   }
 
   #[test]
   fn match_slugs() {
-    let lines = split("Lorem dev/api/[slug]/foo, lorem");
+    let output = "Lorem dev/api/[slug]/foo, lorem";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 1);
-    assert_eq!(results.get(0).unwrap().text.clone(), "dev/api/[slug]/foo");
+    assert_eq!(results.get(0).unwrap().text, "dev/api/[slug]/foo");
   }
 
   #[test]
   fn match_uids() {
-    let lines = split("Lorem ipsum 123e4567-e89b-12d3-a456-426655440000 lorem\n Lorem lorem lorem");
+    let output = "Lorem ipsum 123e4567-e89b-12d3-a456-426655440000 lorem\n Lorem lorem lorem";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 1);
   }
 
   #[test]
   fn match_shas() {
-    let lines = split("Lorem fd70b5695 5246ddf f924213 lorem\n Lorem 973113963b491874ab2e372ee60d4b4cb75f717c lorem");
+    let output = "Lorem fd70b5695 5246ddf f924213 lorem\n Lorem 973113963b491874ab2e372ee60d4b4cb75f717c lorem";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 4);
-    assert_eq!(results.get(0).unwrap().text.clone(), "fd70b5695");
-    assert_eq!(results.get(1).unwrap().text.clone(), "5246ddf");
-    assert_eq!(results.get(2).unwrap().text.clone(), "f924213");
+    assert_eq!(results.get(0).unwrap().text, "fd70b5695");
+    assert_eq!(results.get(1).unwrap().text, "5246ddf");
+    assert_eq!(results.get(2).unwrap().text, "f924213");
     assert_eq!(
-      results.get(3).unwrap().text.clone(),
+      results.get(3).unwrap().text,
       "973113963b491874ab2e372ee60d4b4cb75f717c"
     );
   }
 
   #[test]
   fn match_ips() {
-    let lines = split("Lorem ipsum 127.0.0.1 lorem\n Lorem 255.255.10.255 lorem 127.0.0.1 lorem");
+    let output = "Lorem ipsum 127.0.0.1 lorem\n Lorem 255.255.10.255 lorem 127.0.0.1 lorem";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 3);
-    assert_eq!(results.get(0).unwrap().text.clone(), "127.0.0.1");
-    assert_eq!(results.get(1).unwrap().text.clone(), "255.255.10.255");
-    assert_eq!(results.get(2).unwrap().text.clone(), "127.0.0.1");
+    assert_eq!(results.get(0).unwrap().text, "127.0.0.1");
+    assert_eq!(results.get(1).unwrap().text, "255.255.10.255");
+    assert_eq!(results.get(2).unwrap().text, "127.0.0.1");
   }
 
   #[test]
   fn match_ipv6s() {
-    let lines = split("Lorem ipsum fe80::2:202:fe4 lorem\n Lorem 2001:67c:670:202:7ba8:5e41:1591:d723 lorem fe80::2:1 lorem ipsum fe80:22:312:fe::1%eth0");
+    let output = "Lorem ipsum fe80::2:202:fe4 lorem\n Lorem 2001:67c:670:202:7ba8:5e41:1591:d723 lorem fe80::2:1 lorem ipsum fe80:22:312:fe::1%eth0";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 4);
-    assert_eq!(results.get(0).unwrap().text.clone(), "fe80::2:202:fe4");
+    assert_eq!(results.get(0).unwrap().text, "fe80::2:202:fe4");
     assert_eq!(
-      results.get(1).unwrap().text.clone(),
+      results.get(1).unwrap().text,
       "2001:67c:670:202:7ba8:5e41:1591:d723"
     );
-    assert_eq!(results.get(2).unwrap().text.clone(), "fe80::2:1");
-    assert_eq!(results.get(3).unwrap().text.clone(), "fe80:22:312:fe::1%eth0");
+    assert_eq!(results.get(2).unwrap().text, "fe80::2:1");
+    assert_eq!(results.get(3).unwrap().text, "fe80:22:312:fe::1%eth0");
   }
 
   #[test]
   fn match_markdown_urls() {
-    let lines = split("Lorem ipsum [link](https://github.io?foo=bar) ![](http://cdn.com/img.jpg) lorem");
+    let output = "Lorem ipsum [link](https://github.io?foo=bar) ![](http://cdn.com/img.jpg) lorem";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 2);
-    assert_eq!(results.get(0).unwrap().pattern.clone(), "markdown_url");
-    assert_eq!(results.get(0).unwrap().text.clone(), "https://github.io?foo=bar");
-    assert_eq!(results.get(1).unwrap().pattern.clone(), "markdown_url");
-    assert_eq!(results.get(1).unwrap().text.clone(), "http://cdn.com/img.jpg");
+    assert_eq!(results.get(0).unwrap().pattern, "markdown_url");
+    assert_eq!(results.get(0).unwrap().text, "https://github.io?foo=bar");
+    assert_eq!(results.get(1).unwrap().pattern, "markdown_url");
+    assert_eq!(results.get(1).unwrap().text, "http://cdn.com/img.jpg");
   }
 
   #[test]
   fn match_urls() {
-    let lines = split("Lorem ipsum https://www.rust-lang.org/tools lorem\n Lorem ipsumhttps://crates.io lorem https://github.io?foo=bar lorem ssh://github.io");
+    let output = "Lorem ipsum https://www.rust-lang.org/tools lorem\n Lorem ipsumhttps://crates.io lorem https://github.io?foo=bar lorem ssh://github.io";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 4);
-    assert_eq!(results.get(0).unwrap().text.clone(), "https://www.rust-lang.org/tools");
-    assert_eq!(results.get(0).unwrap().pattern.clone(), "url");
-    assert_eq!(results.get(1).unwrap().text.clone(), "https://crates.io");
-    assert_eq!(results.get(1).unwrap().pattern.clone(), "url");
-    assert_eq!(results.get(2).unwrap().text.clone(), "https://github.io?foo=bar");
-    assert_eq!(results.get(2).unwrap().pattern.clone(), "url");
-    assert_eq!(results.get(3).unwrap().text.clone(), "ssh://github.io");
-    assert_eq!(results.get(3).unwrap().pattern.clone(), "url");
+    assert_eq!(results.get(0).unwrap().text, "https://www.rust-lang.org/tools");
+    assert_eq!(results.get(0).unwrap().pattern, "url");
+    assert_eq!(results.get(1).unwrap().text, "https://crates.io");
+    assert_eq!(results.get(1).unwrap().pattern, "url");
+    assert_eq!(results.get(2).unwrap().text, "https://github.io?foo=bar");
+    assert_eq!(results.get(2).unwrap().pattern, "url");
+    assert_eq!(results.get(3).unwrap().text, "ssh://github.io");
+    assert_eq!(results.get(3).unwrap().pattern, "url");
   }
 
   #[test]
   fn match_addresses() {
-    let lines = split("Lorem 0xfd70b5695 0x5246ddf lorem\n Lorem 0x973113tlorem");
+    let output = "Lorem 0xfd70b5695 0x5246ddf lorem\n Lorem 0x973113tlorem";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 3);
-    assert_eq!(results.get(0).unwrap().text.clone(), "0xfd70b5695");
-    assert_eq!(results.get(1).unwrap().text.clone(), "0x5246ddf");
-    assert_eq!(results.get(2).unwrap().text.clone(), "0x973113");
+    assert_eq!(results.get(0).unwrap().text, "0xfd70b5695");
+    assert_eq!(results.get(1).unwrap().text, "0x5246ddf");
+    assert_eq!(results.get(2).unwrap().text, "0x973113");
   }
 
   #[test]
   fn match_hex_colors() {
-    let lines = split("Lorem #fd7b56 lorem #FF00FF\n Lorem #00fF05 lorem #abcd00 lorem #afRR00");
+    let output = "Lorem #fd7b56 lorem #FF00FF\n Lorem #00fF05 lorem #abcd00 lorem #afRR00";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 4);
-    assert_eq!(results.get(0).unwrap().text.clone(), "#fd7b56");
-    assert_eq!(results.get(1).unwrap().text.clone(), "#FF00FF");
-    assert_eq!(results.get(2).unwrap().text.clone(), "#00fF05");
-    assert_eq!(results.get(3).unwrap().text.clone(), "#abcd00");
+    assert_eq!(results.get(0).unwrap().text, "#fd7b56");
+    assert_eq!(results.get(1).unwrap().text, "#FF00FF");
+    assert_eq!(results.get(2).unwrap().text, "#00fF05");
+    assert_eq!(results.get(3).unwrap().text, "#abcd00");
   }
 
   #[test]
   fn match_ipfs() {
-    let lines = split("Lorem QmRdbNSxDJBXmssAc9fvTtux4duptMvfSGiGuq6yHAQVKQ lorem Qmfoobar");
+    let output = "Lorem QmRdbNSxDJBXmssAc9fvTtux4duptMvfSGiGuq6yHAQVKQ lorem Qmfoobar";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 1);
     assert_eq!(
-      results.get(0).unwrap().text.clone(),
+      results.get(0).unwrap().text,
       "QmRdbNSxDJBXmssAc9fvTtux4duptMvfSGiGuq6yHAQVKQ"
     );
   }
 
   #[test]
   fn match_process_port() {
-    let lines =
-      split("Lorem 5695 52463 lorem\n Lorem 973113 lorem 99999 lorem 8888 lorem\n   23456 lorem 5432 lorem 23444");
+    let output =
+      "Lorem 5695 52463 lorem\n Lorem 973113 lorem 99999 lorem 8888 lorem\n   23456 lorem 5432 lorem 23444";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 8);
   }
 
   #[test]
   fn match_diff_a() {
-    let lines = split("Lorem lorem\n--- a/src/main.rs");
+    let output = "Lorem lorem\n--- a/src/main.rs";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 1);
-    assert_eq!(results.get(0).unwrap().text.clone(), "src/main.rs");
+    assert_eq!(results.get(0).unwrap().text, "src/main.rs");
   }
 
   #[test]
   fn match_diff_b() {
-    let lines = split("Lorem lorem\n+++ b/src/main.rs");
+    let output = "Lorem lorem\n+++ b/src/main.rs";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 1);
-    assert_eq!(results.get(0).unwrap().text.clone(), "src/main.rs");
+    assert_eq!(results.get(0).unwrap().text, "src/main.rs");
   }
 
   #[test]
   fn match_diff_summary() {
-    let lines = split("diff --git a/samples/test1 b/samples/test2");
+    let output = "diff --git a/samples/test1 b/samples/test2";
     let custom = [].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 2);
-    assert_eq!(results.get(0).unwrap().text.clone(), "samples/test1");
-    assert_eq!(results.get(1).unwrap().text.clone(), "samples/test2");
+    assert_eq!(results.get(0).unwrap().text, "samples/test1");
+    assert_eq!(results.get(1).unwrap().text, "samples/test2");
   }
 
   #[test]
   fn priority() {
-    let lines = split("Lorem [link](http://foo.bar) ipsum CUSTOM-52463 lorem ISSUE-123 lorem\nLorem /var/fd70b569/9999.log 52463 lorem\n Lorem 973113 lorem 123e4567-e89b-12d3-a456-426655440000 lorem 8888 lorem\n  https://crates.io/23456/fd70b569 lorem");
+    let output = "Lorem [link](http://foo.bar) ipsum CUSTOM-52463 lorem ISSUE-123 lorem\nLorem /var/fd70b569/9999.log 52463 lorem\n Lorem 973113 lorem 123e4567-e89b-12d3-a456-426655440000 lorem 8888 lorem\n  https://crates.io/23456/fd70b569 lorem";
     let custom = ["CUSTOM-[0-9]{4,}", "ISSUE-[0-9]{3}"].to_vec();
-    let results = State::new(&lines, "abcd", &custom).matches(false, false);
+    let results = State::new(output, "abcd", &custom).matches(false, false);
 
     assert_eq!(results.len(), 9);
-    assert_eq!(results.get(0).unwrap().text.clone(), "http://foo.bar");
-    assert_eq!(results.get(1).unwrap().text.clone(), "CUSTOM-52463");
-    assert_eq!(results.get(2).unwrap().text.clone(), "ISSUE-123");
-    assert_eq!(results.get(3).unwrap().text.clone(), "/var/fd70b569/9999.log");
-    assert_eq!(results.get(4).unwrap().text.clone(), "52463");
-    assert_eq!(results.get(5).unwrap().text.clone(), "973113");
+    assert_eq!(results.get(0).unwrap().text, "http://foo.bar");
+    assert_eq!(results.get(1).unwrap().text, "CUSTOM-52463");
+    assert_eq!(results.get(2).unwrap().text, "ISSUE-123");
+    assert_eq!(results.get(3).unwrap().text, "/var/fd70b569/9999.log");
+    assert_eq!(results.get(4).unwrap().text, "52463");
+    assert_eq!(results.get(5).unwrap().text, "973113");
     assert_eq!(
-      results.get(6).unwrap().text.clone(),
+      results.get(6).unwrap().text,
       "123e4567-e89b-12d3-a456-426655440000"
     );
-    assert_eq!(results.get(7).unwrap().text.clone(), "8888");
-    assert_eq!(results.get(8).unwrap().text.clone(), "https://crates.io/23456/fd70b569");
+    assert_eq!(results.get(7).unwrap().text, "8888");
+    assert_eq!(results.get(8).unwrap().text, "https://crates.io/23456/fd70b569");
   }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -29,6 +29,7 @@ const PATTERNS: [(&str, &str); 15] = [
 pub struct Match<'a> {
   pub start: usize,
   pub end: usize,
+  pub prev_end: usize,
   pub pattern: &'a str,
   pub text: &'a str,
   pub hint: Option<String>,
@@ -93,7 +94,7 @@ impl<'a> State<'a> {
 
     let mut chunk: &str = self.output;
     let mut offset: usize = 0;
-    let mut end_last: usize = 0;
+    let mut prev_end: usize = 0;
 
     loop {
       // For this line we search which patterns match, all of them.
@@ -127,16 +128,16 @@ impl<'a> State<'a> {
           if *name != "bash" {
             for (subtext, substart) in captures.iter() {
               let start = offset + matching.start() + *substart;
-              if start > end_last {
-                end_last = start + subtext.len();
-                matches.push(Match {
-                  start,
-                  end: end_last,
-                  pattern: name,
-                  text: subtext,
-                  hint: None,
-                });
-              }
+              let end = start + subtext.len();
+              matches.push(Match {
+                start,
+                end,
+                prev_end,
+                pattern: name,
+                text: subtext,
+                hint: None,
+              });
+              prev_end = end;
             }
           }
 

--- a/src/swapper.rs
+++ b/src/swapper.rs
@@ -311,7 +311,7 @@ impl<'a> Swapper<'a> {
 
   pub fn execute_command(&mut self) {
     let content = self.content.clone().unwrap();
-    let items: Vec<&str> = content.split('\n').collect();
+    let items: Vec<&str> = content.split('\0').collect();
 
     if items.len() > 1 {
       let text = items

--- a/src/view.rs
+++ b/src/view.rs
@@ -449,7 +449,7 @@ mod tests {
       skip: 0,
       multi: false,
       contrast: false,
-      position: &"",
+      position: "",
       matches: vec![],
       select_foreground_color: colors::get_color("default"),
       select_background_color: colors::get_color("default"),

--- a/src/view.rs
+++ b/src/view.rs
@@ -173,6 +173,14 @@ impl<'a> View<'a> {
       }
     }
 
+    if output.ends_with("\r\n") {
+      output.pop();
+      output.pop();
+    } else if output.ends_with('\n') {
+      output.pop();
+      output = output.replace('\n', "\r\n");
+    };
+
     print!("\r\n{}", output);
     stdout.flush().unwrap();
   }

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,14 +1,12 @@
 use super::*;
-use std::char;
 use std::io::{stdout, Read, Write};
+use itertools::Itertools;
 use termion::async_stdin;
 use termion::event::Key;
 use termion::input::TermRead;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use termion::{color, cursor};
-
-use unicode_width::UnicodeWidthStr;
 
 pub struct View<'a> {
   state: &'a mut state::State<'a>,
@@ -95,17 +93,10 @@ impl<'a> View<'a> {
   fn render(&self, stdout: &mut dyn Write, typed_hint: &str) -> () {
     write!(stdout, "{}", cursor::Hide).unwrap();
 
-    for (index, line) in self.state.lines.iter().enumerate() {
-      let clean = line.trim_end_matches(|c: char| c.is_whitespace());
-
-      if !clean.is_empty() {
-        print!("{goto}{text}", goto = cursor::Goto(1, index as u16 + 1), text = line);
-      }
-    }
-
+    let mut output = self.state.output.to_string();
     let selected = self.matches.get(self.skip);
 
-    for mat in self.matches.iter() {
+    for mat in self.matches.iter().sorted_by_key(|x| usize::MAX - x.start) {
       let chosen_hint = self.chosen.iter().any(|(hint, _)| hint == mat.text);
 
       let selected_color = if chosen_hint {
@@ -123,58 +114,66 @@ impl<'a> View<'a> {
         &self.background_color
       };
 
-      // Find long utf sequences and extract it from mat.x
-      let line = &self.state.lines[mat.y as usize];
-      let prefix = &line[0..mat.x as usize];
-      let extra = prefix.width_cjk() - prefix.chars().count();
-      let offset = (mat.x as u16) - (extra as u16);
-      let text = self.make_hint_text(mat.text);
-
-      print!(
-        "{goto}{background}{foregroud}{text}{resetf}{resetb}",
-        goto = cursor::Goto(offset + 1, mat.y as u16 + 1),
-        foregroud = color::Fg(&**selected_color),
-        background = color::Bg(&**selected_background_color),
-        resetf = color::Fg(color::Reset),
-        resetb = color::Bg(color::Reset),
-        text = &text
-      );
+      let matched_text = self.make_hint_text(mat.text);
 
       if let Some(ref hint) = mat.hint {
+        let hint_text = self.make_hint_text(hint.as_str());
+        let matched_text_len = matched_text.chars().count();
         let extra_position = match self.position {
-          "right" => text.width_cjk() - hint.len(),
-          "off_left" => 0 - hint.len() - if self.contrast { 2 } else { 0 },
-          "off_right" => text.width_cjk(),
+          "right" => matched_text_len - hint_text.len(),
           _ => 0,
         };
+        let extra_position_end = extra_position + hint_text.len();
 
-        let text = self.make_hint_text(hint.as_str());
-        let final_position = std::cmp::max(offset as i16 + extra_position as i16, 0);
-
-        print!(
-          "{goto}{background}{foregroud}{text}{resetf}{resetb}",
-          goto = cursor::Goto(final_position as u16 + 1, mat.y as u16 + 1),
-          foregroud = color::Fg(&*self.hint_foreground_color),
-          background = color::Bg(&*self.hint_background_color),
-          resetf = color::Fg(color::Reset),
-          resetb = color::Bg(color::Reset),
-          text = &text
-        );
-
-        if hint.starts_with(typed_hint) {
-          print!(
-            "{goto}{background}{foregroud}{text}{resetf}{resetb}",
-            goto = cursor::Goto(final_position as u16 + 1, mat.y as u16 + 1),
-            foregroud = color::Fg(&*self.multi_foreground_color),
-            background = color::Bg(&*self.multi_background_color),
+        if !typed_hint.is_empty() && hint.starts_with(typed_hint) {
+          output = format!(
+            "{start}{b}{f}{text_start}{typed_b}{typed_f}{typed}{hint_b}{hint_f}{hint}{b}{f}{text_end}{resetf}{resetb}{end}",
+            start = &output[0..mat.start],
+            f = color::Fg(&**selected_color),
+            b = color::Bg(&**selected_background_color),
+            typed_f = color::Fg(&*self.multi_foreground_color),
+            typed_b = color::Bg(&*self.multi_background_color),
+            typed = &typed_hint,
+            hint_f = color::Fg(&*self.hint_foreground_color),
+            hint_b = color::Bg(&*self.hint_background_color),
+            hint = &hint_text[typed_hint.len()..],
             resetf = color::Fg(color::Reset),
             resetb = color::Bg(color::Reset),
-            text = &typed_hint
+            text_start = &matched_text.chars().take(extra_position).collect::<String>(),
+            text_end = &matched_text.chars().skip(extra_position_end).collect::<String>(),
+            end = &output[mat.end..],
           );
-        }
+        } else {
+          output = format!(
+            "{start}{b}{f}{text_start}{hint_b}{hint_f}{hint}{b}{f}{text_end}{resetf}{resetb}{end}",
+            start = &output[0..mat.start],
+            f = color::Fg(&**selected_color),
+            b = color::Bg(&**selected_background_color),
+            hint_f = color::Fg(&*self.hint_foreground_color),
+            hint_b = color::Bg(&*self.hint_background_color),
+            hint = &hint_text,
+            resetf = color::Fg(color::Reset),
+            resetb = color::Bg(color::Reset),
+            text_start = &matched_text.chars().take(extra_position).collect::<String>(),
+            text_end = &matched_text.chars().skip(extra_position_end).collect::<String>(),
+            end = &output[mat.end..],
+          );
+        };
+      } else {
+        output = format!(
+          "{start}{b}{f}{text}{resetf}{resetb}{end}",
+          start = &output[0..mat.start],
+          f = color::Fg(&**selected_color),
+          b = color::Bg(&**selected_background_color),
+          resetf = color::Fg(color::Reset),
+          resetb = color::Bg(color::Reset),
+          text = &matched_text,
+          end = &output[mat.end..],
+        );
       }
     }
 
+    print!("\r\n{}", output);
     stdout.flush().unwrap();
   }
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,4 +1,5 @@
 use super::*;
+use regex::Regex;
 use std::io::{stdout, Read, Write};
 use itertools::Itertools;
 use termion::async_stdin;
@@ -297,7 +298,9 @@ impl<'a> View<'a> {
     } else if output.ends_with('\n') {
       output.pop();
       output = output.replace('\n', "\r\n");
-    };
+    } else if Regex::new("[^\r]\n").unwrap().is_match(&output) {
+      output = output.replace('\n', "\r\n");
+    }
 
     print!("\r\n{}", output);
     stdout.flush().unwrap();

--- a/src/view.rs
+++ b/src/view.rs
@@ -90,7 +90,7 @@ impl<'a> View<'a> {
     }
   }
 
-  fn render(&self, stdout: &mut dyn Write, typed_hint: &str) -> () {
+  fn render(&self, stdout: &mut dyn Write, typed_hint: &str) {
     write!(stdout, "{}", cursor::Hide).unwrap();
 
     let mut output = self.state.output.to_string();
@@ -188,8 +188,7 @@ impl<'a> View<'a> {
       .iter()
       .filter_map(|m| m.hint.clone())
       .max_by(|x, y| x.len().cmp(&y.len()))
-      .unwrap()
-      .clone();
+      .unwrap();
 
     self.render(stdout, &typed_hint);
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -310,15 +310,11 @@ impl<'a> View<'a> {
 mod tests {
   use super::*;
 
-  fn split(output: &str) -> Vec<&str> {
-    output.split("\n").collect::<Vec<&str>>()
-  }
-
   #[test]
   fn hint_text() {
-    let lines = split("lorem 127.0.0.1 lorem");
+    let output = "lorem 127.0.0.1 lorem";
     let custom = [].to_vec();
-    let mut state = state::State::new(&lines, "abcd", &custom);
+    let mut state = state::State::new(output, "abcd", &custom);
     let mut view = View {
       state: &mut state,
       skip: 0,


### PR DESCRIPTION
Example of tmux regexp capturing quotes:

```
set-option -g @thumbs-regexp-1 "(?:^|[^\\\\])(\"(?:\\\\\"|[^\"\n])*[^\\\\\n]\"|'(?:\\\\'|[^'\n])*[^\\\\\n]'|`(?:\\\\`|[^`\n])*[^\\\\\n]`)"
```
