### PR TITLE
README: remove superfluous file sourcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ You can add this line to your list of [TPM](https://github.com/tmux-plugins/tpm)
 
 ```
 set -g @plugin 'fcsonline/tmux-thumbs'
-
-run-shell ~/.tmux/plugins/tmux-thumbs/tmux-thumbs.tmux
 ```
 
 To be able to install the plugin just hit <kbd>prefix</kbd> + <kbd>I</kbd>. You should now be able to use


### PR DESCRIPTION
According to TPM docs: when it sources a plugin, TPM executes all `*.tmux` files in your plugins' directory.

Ref: https://github.com/tmux-plugins/tpm/blob/master/docs/how_to_create_plugin.md#2-create-a-tmux-plugin-run-file