### PR TITLE
Add hint position test, README entry about ligatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ I was curious to know if this was possible to be written in [Rust](https://www.r
 
 ## Troubleshooting
 
+> `tmux-thumbs` isn't as fast as expected
+
 `tmux-thumbs` must work lighting fast. If you are facing a slow performance capturing the screen hints try to configure Tmux with these settings:
 
 ```
@@ -511,14 +513,22 @@ set -g visual-silence on
 
 You can read a bit more about this issue here: https://github.com/fcsonline/tmux-thumbs/issues/88
 
-Every time I use `tmux-thumbs`, dead panes are created. Just review if you have
-this setting on:
+> Every time I use `tmux-thumbs`, dead panes are created. 
+
+Just review if you have this setting on:
 
 ```
 set -g remain-on-exit on
 ```
 
 You can read a bit more about this issue here: https://github.com/fcsonline/tmux-thumbs/issues/84
+
+> Sometimes I see the hints showing up in the wrong starting location.
+
+This is likely because the lines with the incorrectly-positioned hints have ligatures. Many CLI utilities
+and prompt themes have ligatures.
+
+You can read a bit more about this issue here: https://github.com/fcsonline/tmux-thumbs/issues/158 https://github.com/fcsonline/tmux-thumbs/pull/161
 
 ## Donations
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -482,7 +482,7 @@ mod tests {
     assert_eq!(results.get(1).unwrap().y.clone(), 0);
     assert_eq!(results.get(2).unwrap().x.clone(), 1);
     assert_eq!(results.get(2).unwrap().y.clone(), 1);
-    // this should be 1, but current regex matching doesn't treat ligatures as a single character
+    // this should be 1, but regex matching won't be aware of ligatures
     assert_eq!(results.get(3).unwrap().x.clone(), 3);
     assert_eq!(results.get(3).unwrap().y.clone(), 2);
   }

--- a/src/state.rs
+++ b/src/state.rs
@@ -471,17 +471,19 @@ mod tests {
 
   #[test]
   fn hint_positioning() {
-    // first line contains a single matched string, second line has a prefix, third line has a ligature
-    let lines = split("20240913-lorem-ipsum\n-20240913-lorem-ipsum-1\n↳20240913-lorem-ipsum-2");
+    // first line contains two matched strings, second line has a prefix, third line has a ligature
+    let lines = split("20240913-lorem-ipsum 10240913-lorem-ipsum-0\n-20240913-lorem-ipsum-1\n↳20240913-lorem-ipsum-2");
     let custom = [].to_vec();
     let results = State::new(&lines, "abcd", &custom).matches(false, true);
 
     assert_eq!(results.get(0).unwrap().x.clone(), 0);
     assert_eq!(results.get(0).unwrap().y.clone(), 0);
-    assert_eq!(results.get(1).unwrap().x.clone(), 1);
-    assert_eq!(results.get(1).unwrap().y.clone(), 1);
+    assert_eq!(results.get(1).unwrap().x.clone(), 21);
+    assert_eq!(results.get(1).unwrap().y.clone(), 0);
+    assert_eq!(results.get(2).unwrap().x.clone(), 1);
+    assert_eq!(results.get(2).unwrap().y.clone(), 1);
     // this should be 1, but current regex matching doesn't treat ligatures as a single character
-    assert_eq!(results.get(2).unwrap().x.clone(), 3);
-    assert_eq!(results.get(2).unwrap().y.clone(), 2);
+    assert_eq!(results.get(3).unwrap().x.clone(), 3);
+    assert_eq!(results.get(3).unwrap().y.clone(), 2);
   }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -468,4 +468,20 @@ mod tests {
     assert_eq!(results.get(7).unwrap().text.clone(), "8888");
     assert_eq!(results.get(8).unwrap().text.clone(), "https://crates.io/23456/fd70b569");
   }
+
+  #[test]
+  fn hint_positioning() {
+    // first line contains a single matched string, second line has a prefix, third line has a ligature
+    let lines = split("20240913-lorem-ipsum\n-20240913-lorem-ipsum-1\n↳20240913-lorem-ipsum-2");
+    let custom = [].to_vec();
+    let results = State::new(&lines, "abcd", &custom).matches(false, true);
+
+    assert_eq!(results.get(0).unwrap().x.clone(), 0);
+    assert_eq!(results.get(0).unwrap().y.clone(), 0);
+    assert_eq!(results.get(1).unwrap().x.clone(), 1);
+    assert_eq!(results.get(1).unwrap().y.clone(), 1);
+    // this should be 1, but tmux-thumbs doesn't handle ligatures
+    assert_eq!(results.get(2).unwrap().x.clone(), 3);
+    assert_eq!(results.get(2).unwrap().y.clone(), 2);
+  }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -480,7 +480,7 @@ mod tests {
     assert_eq!(results.get(0).unwrap().y.clone(), 0);
     assert_eq!(results.get(1).unwrap().x.clone(), 1);
     assert_eq!(results.get(1).unwrap().y.clone(), 1);
-    // this should be 1, but tmux-thumbs doesn't handle ligatures
+    // this should be 1, but current regex matching doesn't treat ligatures as a single character
     assert_eq!(results.get(2).unwrap().x.clone(), 3);
     assert_eq!(results.get(2).unwrap().y.clone(), 2);
   }

--- a/src/state.rs
+++ b/src/state.rs
@@ -482,7 +482,7 @@ mod tests {
     assert_eq!(results.get(1).unwrap().y.clone(), 0);
     assert_eq!(results.get(2).unwrap().x.clone(), 1);
     assert_eq!(results.get(2).unwrap().y.clone(), 1);
-    // this should be 1, but regex matching won't be aware of ligatures
+    // regex matching can't be aware of ligatures
     assert_eq!(results.get(3).unwrap().x.clone(), 3);
     assert_eq!(results.get(3).unwrap().y.clone(), 2);
   }


### PR DESCRIPTION
I had an issue with hint positions being incorrect, and noticed it only happened in certain places.

```
$ echo "a0240913-ligatures-test"
s0240913-ligatures-test
$ echo "-d0240913-ligatures-test"
-f0240913-ligatures-test
$ echo "↳20q0240913-ligatures-test
↳20w0240913-ligatures-test
```

It's all about ligatures!

Add a test since none of the existing tests check for hint positioning. Added a troubleshooting
entry in the README as well.

As for actually solving this issue, we would need something like https://github.com/fcsonline/tmux-thumbs/pull/162